### PR TITLE
chore(server): configure enviroment var to manage allowd-origins in s…

### DIFF
--- a/server/.env.example
+++ b/server/.env.example
@@ -3,3 +3,4 @@ LINKEDIN_API_KEY=<api-key>
 OPENAI_API_KEY=<api-key>
 OPENAI_MODEL=gpt-4.1-mini
 OPENAI_MODEL=gpt-4.1
+ALLOWED_ORIGINS=http://localhost:5173,http://localhost:3000

--- a/server/src/apps/express-server/middlewares/cors.middleware.ts
+++ b/server/src/apps/express-server/middlewares/cors.middleware.ts
@@ -1,15 +1,12 @@
 import cors from 'cors'
 
-const allowedOrigins = [
-  'http://localhost:5173',
-  'http://localhost:5174',
-  'http://localhost:3000',
-]
+const allowedOrigins = process.env.ALLOWED_ORIGINS?.split(',') || []
 
 export const corsMiddleware = cors({
   origin: (origin, callback) => {
-    console.log('Origin:', origin)
-    if (!origin || allowedOrigins.includes(origin)) {
+    const originStr = origin || ''
+    // Allow requests with no origin (like mobile apps or curl requests)
+    if (!origin || allowedOrigins.includes(originStr)) {
       callback(null, true)
     } else {
       callback(new Error('Not allowed by CORS'))


### PR DESCRIPTION
## ¿Que hace este PR?

Configura y hace los cambios necesarios para que la variable de entorno ALLOWED_ORIGINS sea la usada para definir lo origenes que se permiten que accedan a la API REST del servidor

## ¿Por que es importante este  PR?

Permite controlar de una forma mas amigable los origenes que tienen acceso a la API REST.

Como el cliente esta montado en vercel y se estan usando urls de prueba proporcionadas por vercel. Es mas sencillo manejar configuracion para que estos clientes deployados en vercel tengan acceso a la API y  hacer pruebas.